### PR TITLE
Config Version Detection in Elements

### DIFF
--- a/compiler/element/__init__.py
+++ b/compiler/element/__init__.py
@@ -114,6 +114,7 @@ def gen_code(
             request_message_name=request_message_name,
             response_message_name=response_message_name,
             message_field_types=message_field_types,
+            tag=tag,
         )
 
     printer = Printer()

--- a/compiler/element/__init__.py
+++ b/compiler/element/__init__.py
@@ -31,6 +31,7 @@ def gen_code(
     proto_path: str,
     method_name: str,
     server: str,
+    tag: str,
     proto_module_name: str = "",
     proto_module_location: str = "",
     verbose: bool = False,
@@ -47,6 +48,7 @@ def gen_code(
         proto_path: (str):  The path to the proto file (e.g., hello.proto).
         method_name: (str): The name of the method to be used in the proto file.
         verbose (bool, optional): If True, provides detailed logging. Defaults to False.
+        tag (str): The tag number for the current version.
 
     Raises:
         FileNotFoundError: If the proto file deos not exist.
@@ -97,6 +99,7 @@ def gen_code(
             response_message_name=response_message_name,
             message_field_types=message_field_types,
             mode=backend_name,
+            tag=tag,
         )
     elif backend_name == "grpc":
         assert proto_module_name != "" and proto_module_location != ""

--- a/compiler/element/backend/envoy/boilerplate.py
+++ b/compiler/element/backend/envoy/boilerplate.py
@@ -19,6 +19,19 @@ lazy_static! {{
     static ref RPC_TAG: RwLock<HashMap<u32, String>> = RwLock::new(HashMap::new());
 }}
 
+pub fn tag_check(context_id: u32) -> bool {{
+    let rpc_tag_inner = RPC_TAG.read().unwrap();
+    match rpc_tag_inner.get(&context_id) {{
+        Some(tag) => {{
+            if tag == "{Tag}" {{
+                return true;
+            }}
+        }}
+        _ => {{}}
+    }}
+    false
+}}
+
 {GlobalVariables}
 
 {GlobalFuncDef}
@@ -107,14 +120,9 @@ impl HttpContext for {FilterName}Body {{
         // if !end_of_stream {{
         //     return Action::Continue;
         // }}
-        let rpc_tag_inner = RPC_TAG.read().unwrap();
-        match rpc_tag_inner.get(&self.context_id) {{
-            Some(tag) => {{
-                if tag != "{Tag}" {{
-                    return Action::Continue;
-                }}
-            }}
-            _ => log::warn!("no tag value found for rpc {{}}", self.context_id),
+        if !tag_check(self.context_id) {{
+            log::warn!("Tag missing or mismatch, skip");
+            return Action::Continue;
         }}
         {RequestBody}
         Action::Continue
@@ -125,14 +133,9 @@ impl HttpContext for {FilterName}Body {{
         // if !end_of_stream {{
         //    return Action::Continue;
         // }}
-        let rpc_tag_inner = RPC_TAG.read().unwrap();
-        match rpc_tag_inner.get(&self.context_id) {{
-            Some(tag) => {{
-                if tag != "{Tag}" {{
-                    return Action::Continue;
-                }}
-            }}
-            _ => log::warn!("no tag value found for rpc {{}}", self.context_id),
+        if !tag_check(self.context_id) {{
+            log::warn!("Tag missing or mismatch, skip");
+            return Action::Continue;
         }}
         {ResponseHeaders}
         Action::Continue
@@ -143,14 +146,9 @@ impl HttpContext for {FilterName}Body {{
         // if !end_of_stream {{
         //    return Action::Continue;
         // }}
-        let rpc_tag_inner = RPC_TAG.read().unwrap();
-        match rpc_tag_inner.get(&self.context_id) {{
-            Some(tag) => {{
-                if tag != "{Tag}" {{
-                    return Action::Continue;
-                }}
-            }}
-            _ => log::warn!("no tag value found for rpc {{}}", self.context_id),
+        if !tag_check(self.context_id) {{
+            log::warn!("Tag missing or mismatch, skip");
+            return Action::Continue;
         }}
         {ResponseBody}
         Action::Continue

--- a/compiler/element/backend/envoy/boilerplate.py
+++ b/compiler/element/backend/envoy/boilerplate.py
@@ -102,7 +102,7 @@ impl HttpContext for {FilterName}Body {{
             _ => log::warn!("No path header found!"),
         }}
 
-        match self.get_http_request_header(":appnet-rpc-id") {{
+        match self.get_http_request_header(":appnet-rpc-tag") {{
             Some(tag) => {{
                 log::warn!("rpc tag: {{}}", tag);
                 let mut rpc_tag_inner = RPC_TAG.write().unwrap();

--- a/compiler/element/backend/envoy/boilerplate.py
+++ b/compiler/element/backend/envoy/boilerplate.py
@@ -15,6 +15,10 @@ pub mod {ProtoName} {{
     include!(concat!(env!("OUT_DIR"), "/{ProtoName}.rs"));
 }}
 
+lazy_static! {{
+    static ref RPC_TAG: RwLock<HashMap<u32, String>> = RwLock::new(HashMap::new());
+}}
+
 {GlobalVariables}
 
 {GlobalFuncDef}
@@ -85,6 +89,15 @@ impl HttpContext for {FilterName}Body {{
             _ => log::warn!("No path header found!"),
         }}
 
+        match self.get_http_request_header(":appnet-rpc-id") {{
+            Some(tag) => {{
+                log::warn!("rpc tag: {{}}", tag);
+                let mut rpc_tag_inner = RPC_TAG.write().unwrap();
+                rpc_tag_inner.insert(self.context_id, tag);
+            }}
+            _ => log::warn!("No tag header found!"),
+        }}
+
         {RequestHeaders}
         Action::Continue
     }}
@@ -94,6 +107,15 @@ impl HttpContext for {FilterName}Body {{
         // if !end_of_stream {{
         //     return Action::Continue;
         // }}
+        let rpc_tag_inner = RPC_TAG.read().unwrap();
+        match rpc_tag_inner.get(&self.context_id) {{
+            Some(tag) => {{
+                if tag != "{Tag}" {{
+                    return Action::Continue;
+                }}
+            }}
+            _ => log::warn!("no tag value found for rpc {{}}", self.context_id),
+        }}
         {RequestBody}
         Action::Continue
     }}
@@ -103,6 +125,15 @@ impl HttpContext for {FilterName}Body {{
         // if !end_of_stream {{
         //    return Action::Continue;
         // }}
+        let rpc_tag_inner = RPC_TAG.read().unwrap();
+        match rpc_tag_inner.get(&self.context_id) {{
+            Some(tag) => {{
+                if tag != "{Tag}" {{
+                    return Action::Continue;
+                }}
+            }}
+            _ => log::warn!("no tag value found for rpc {{}}", self.context_id),
+        }}
         {ResponseHeaders}
         Action::Continue
     }}
@@ -112,6 +143,15 @@ impl HttpContext for {FilterName}Body {{
         // if !end_of_stream {{
         //    return Action::Continue;
         // }}
+        let rpc_tag_inner = RPC_TAG.read().unwrap();
+        match rpc_tag_inner.get(&self.context_id) {{
+            Some(tag) => {{
+                if tag != "{Tag}" {{
+                    return Action::Continue;
+                }}
+            }}
+            _ => log::warn!("no tag value found for rpc {{}}", self.context_id),
+        }}
         {ResponseBody}
         Action::Continue
     }}

--- a/compiler/element/backend/envoy/boilerplate.py
+++ b/compiler/element/backend/envoy/boilerplate.py
@@ -102,9 +102,8 @@ impl HttpContext for {FilterName}Body {{
             _ => log::warn!("No path header found!"),
         }}
 
-        match self.get_http_request_header(":appnet-rpc-tag") {{
+        match self.get_http_request_header("appnet-config-version") {{
             Some(tag) => {{
-                log::warn!("rpc tag: {{}}", tag);
                 let mut rpc_tag_inner = RPC_TAG.write().unwrap();
                 rpc_tag_inner.insert(self.context_id, tag);
             }}

--- a/compiler/element/backend/envoy/finalizer.py
+++ b/compiler/element/backend/envoy/finalizer.py
@@ -23,6 +23,7 @@ def retrieve(ctx: WasmContext, name: str) -> Dict:
         "ResponseBody": "".join(ctx.resp_body_code),
         "ExternalCallResponse": "".join(ctx.external_call_response_code),
         "ProtoName": ctx.proto,
+        "Tag": ctx.tag,
     }
 
 

--- a/compiler/element/backend/envoy/wasmgen.py
+++ b/compiler/element/backend/envoy/wasmgen.py
@@ -19,6 +19,7 @@ class WasmContext:
         message_field_types=None,
         mode: str = "sidecar",
         element_name: str = "",
+        tag: str = "0",
     ) -> None:
         self.state_names: Set[str] = [
             "rpc",
@@ -69,6 +70,7 @@ class WasmContext:
         }
 
         self.mode = mode
+        self.tag = tag
 
     def declare(
         self,

--- a/compiler/element/backend/grpc/boilerplate.py
+++ b/compiler/element/backend/grpc/boilerplate.py
@@ -26,6 +26,13 @@ func {FilterName}ClientInterceptor() grpc.UnaryClientInterceptor {{
 		md, _ := metadata.FromOutgoingContext(ctx)
 		rpc_id, _ := strconv.ParseUint(md.Get("appnet-rpc-id")[0], 10, 32)
 		_ = rpc_id
+
+        // tag := md.Get("appnet-config-version")[0]
+        // if tag != "{Tag}" {{
+		// 	// version mismatch, skip
+		// 	return invoker(ctx, method, req, reply, cc, opts...)
+		// }}
+
     {Request}
 
 		err := invoker(ctx, method, req, reply, cc, opts...)
@@ -63,7 +70,14 @@ func {FilterName}ServerInterceptor() grpc.UnaryServerInterceptor {{
 	return func(ctx context.Context, req interface{{}}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{{}}, error) {{
 		md, _ := metadata.FromIncomingContext(ctx)
 		rpc_id, _ := strconv.ParseUint(md.Get("appnet-rpc-id")[0], 10, 32)
-    _ = rpc_id
+    	_ = rpc_id
+
+        // tag := md.Get("appnet-config-version")[0]
+        // if tag != "{Tag}" {{
+		// 	// version mismatch, skip
+		// 	return handler(ctx, req);
+		// }}
+
     {Request}
 
 		var reply any

--- a/compiler/element/backend/grpc/boilerplate.py
+++ b/compiler/element/backend/grpc/boilerplate.py
@@ -27,11 +27,11 @@ func {FilterName}ClientInterceptor() grpc.UnaryClientInterceptor {{
 		rpc_id, _ := strconv.ParseUint(md.Get("appnet-rpc-id")[0], 10, 32)
 		_ = rpc_id
 
-        // tag := md.Get("appnet-config-version")[0]
-        // if tag != "{Tag}" {{
-		// 	// version mismatch, skip
-		// 	return invoker(ctx, method, req, reply, cc, opts...)
-		// }}
+        tag := md.Get("appnet-config-version")[0]
+        if tag != "{Tag}" {{
+			// version mismatch, skip
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}}
 
     {Request}
 
@@ -72,11 +72,11 @@ func {FilterName}ServerInterceptor() grpc.UnaryServerInterceptor {{
 		rpc_id, _ := strconv.ParseUint(md.Get("appnet-rpc-id")[0], 10, 32)
     	_ = rpc_id
 
-        // tag := md.Get("appnet-config-version")[0]
-        // if tag != "{Tag}" {{
-		// 	// version mismatch, skip
-		// 	return handler(ctx, req);
-		// }}
+        tag := md.Get("appnet-config-version")[0]
+        if tag != "{Tag}" {{
+			// version mismatch, skip
+			return handler(ctx, req);
+		}}
 
     {Request}
 

--- a/compiler/element/backend/grpc/finalizer.py
+++ b/compiler/element/backend/grpc/finalizer.py
@@ -34,6 +34,7 @@ def retrieve(ctx: GoContext, name: str, placement: str) -> Dict:
         "ServerInterceptor": f"{name}ServerInterceptor()"
         if placement == "server"
         else "",
+        "Tag": ctx.tag,
     }
 
 

--- a/compiler/element/backend/grpc/gogen.py
+++ b/compiler/element/backend/grpc/gogen.py
@@ -20,8 +20,10 @@ class GoContext:
         response_message_name=None,
         message_field_types=None,
         element_name: str = "",
+        tag: str = "0",
     ) -> None:
         self.element_name: str = element_name  # Name of the generated element
+        self.tag: str = tag  # version number, used for seamless migration
         self.method_name: str = method_name  # Name of the RPC method
         self.request_message_name: str = request_message_name
         self.response_message_name: str = response_message_name

--- a/compiler/element_compiler_test.py
+++ b/compiler/element_compiler_test.py
@@ -126,6 +126,7 @@ if __name__ == "__main__":
         proto_module_name=proto_module_name,
         proto_module_location=proto_module_location,
         verbose=verbose,
+        tag="0",
     )
     end = datetime.datetime.now()
     LOG.info(f"Code Generation took: {(end-start).microseconds/1000}ms")

--- a/compiler/main.py
+++ b/compiler/main.py
@@ -40,7 +40,7 @@ def parse_args():
         "--tag",
         help="Tag number for the current version",
         type=str,
-        default="0",
+        default="1",
     )
     parser.add_argument(
         "-v",

--- a/compiler/main.py
+++ b/compiler/main.py
@@ -36,6 +36,13 @@ def parse_args():
         required=True,
     )
     parser.add_argument(
+        "-t",
+        "--tag",
+        help="Tag number for the current version",
+        type=str,
+        default="0",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         help="If added, request graphs (i.e., element chains) on each edge will be printed on the terminal",
@@ -108,6 +115,7 @@ def compile_impl(
     proto_path: str,
     method: str,
     server: str,
+    tag: str,
     proto_module_name: str = "",
     proto_module_location: str = "",
 ):
@@ -129,6 +137,7 @@ def compile_impl(
         proto_path,
         method,
         server,
+        tag,
         proto_module_name=proto_module_name,
         proto_module_location=proto_module_location,
     )
@@ -158,6 +167,7 @@ def generate_element_impl(graphirs: Dict[str, GraphIR], pseudo_impl: bool):
                         element.proto,
                         element.method,
                         gir.server,
+                        args.tag,
                         proto_module_name=element.proto_mod_name,
                         proto_module_location=element.proto_mod_location,
                     )


### PR DESCRIPTION
@Romero027 By default, the element compiler uses "1" as the version number (in line with the current tagger, "1" could be reserved as a value for testing).
This PR has been tested on all backends (sidecar, ambient, grpc).